### PR TITLE
Update pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.10.0
 Jinja2==3.1.2
-lxml==4.8.0
+lxml==5.3.0
 requests==2.27.1
-pillow==9.5
+pillow==10.4.0

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
         'jinja2',
         'requests',
         'lxml',
-        'pillow==9.5'
+        'pillow'
     ]
 )

--- a/xml2epub/cover.py
+++ b/xml2epub/cover.py
@@ -13,6 +13,11 @@ from PIL import Image, ImageFont, ImageDraw
 # Local modules
 from .constants import ANIMAL_PIC_DIR, COVER_FONT_PATH, COVER_COLOR_LIST
 
+def textsize(text, font):
+    im = Image.new(mode="P", size=(0, 0))
+    draw = ImageDraw.Draw(im)
+    _, _, width, height = draw.textbbox((0, 0), text=text, font=font)
+    return width, height
 
 def get_cover_image(title: str, author: str, publisher: str) -> Image:
     """
@@ -38,14 +43,14 @@ def get_cover_image(title: str, author: str, publisher: str) -> Image:
     d.rectangle(TITLE_BG_RECTANGLE_TUPLE, fill=cover_color)  # 标题背景方框
     d.rectangle((50, 0, 950, 50), fill=cover_color)  # 页眉方框
     # 作者名字的描写
-    author_text_size = d.textsize(text=author, font=author_font)
+    author_text_size = textsize(text=author, font=author_font)
     if TITLE_BG_RECTANGLE_TUPLE[2] - author_text_size[0] >= TITLE_BG_RECTANGLE_TUPLE[0]:
         author_text_start = TITLE_BG_RECTANGLE_TUPLE[2] - author_text_size[0]
     else:
         author_text_start = TITLE_BG_RECTANGLE_TUPLE[0]
     d.text((author_text_start, 1220), text=author, fill='black', anchor='lt', font=author_font)
     # 标题的描写
-    title_text_size = d.textsize(text=title, font=title_font)
+    title_text_size = textsize(text=title, font=title_font)
     title_rec_size = TITLE_RECTANGLE_TUPLE[2] - TITLE_RECTANGLE_TUPLE[0]
     if title_text_size[0] > title_rec_size:
         # 一行写不下必须分行
@@ -53,7 +58,7 @@ def get_cover_image(title: str, author: str, publisher: str) -> Image:
         lines = re.findall(".{" + str(full_len) + "}", title)
         if len(''.join(lines)) < len(title):
             lines.append(title[len(''.join(lines)):])
-        title_one_word_size = d.textsize(text=title[0], font=title_font)
+        title_one_word_size = textsize(text=title[0], font=title_font)
         par_space = 20  # 段落间距
         actual_line_num = math.floor((TITLE_RECTANGLE_TUPLE[3] - TITLE_RECTANGLE_TUPLE[1]) / (title_one_word_size[1] + par_space))
         if actual_line_num > len(lines):
@@ -65,6 +70,6 @@ def get_cover_image(title: str, author: str, publisher: str) -> Image:
     # 出版商的描写
     d.text((50, 1300), text=publisher, fill=cover_color, anchor='lt', font=publisher_font)
     # 页眉的描写
-    header_text_size = d.textsize(text=f"{author}'s ebook series", font=publisher_font)
+    header_text_size = textsize(text=f"{author}'s ebook series", font=publisher_font)
     d.text((500, 50 + header_text_size[1]), text=f"{author}'s ebook series", fill=cover_color, anchor='mm', font=publisher_font)
     return im


### PR DESCRIPTION
I was motivated to create this PR due to an issue I encountered while trying to build an AWS Lambda layer using the **xml2epub** library.

To simulate the Lambda environment via Docker, you can use the following command:

```bash
# https://hub.docker.com/r/amazon/aws-lambda-python/tags
docker run --rm -d \
  --name aws-lambda-layer \
  --platform linux/amd64 \
  --mount src="$(pwd)",target=/root/workspace,type=bind \
  -it amazon/aws-lambda-python:3.12.2024.06.19.12 bash
```

The issue arises from an outdated dependency on **Pillow**. For some reason, I couldn't get the older version of Pillow to work with my Lambda layer. Specifically, AWS Lambda has compatibility issues with version **9.5**, but everything works perfectly with the latest version, **10.4.0**.

Since this small adjustment to the **xml2epub** code allows it to support the latest Pillow version, I felt inspired to contribute this fix. It's a small change, but I hope it helps others facing the same challenge!

For reference, here's a helpful link with a code snippet that shows how to replace the deprecated `textsize` method:
- [StackOverflow: Python Pillow (PIL) and the textsize attribute](https://stackoverflow.com/questions/77038132/python-pillow-pil-doesnt-recognize-the-attribute-textsize-of-the-object-imag)

Additionally, here are related issues in xml2epub about the Pillow module:
- https://github.com/dfface/xml2epub/issues/37
- https://github.com/dfface/xml2epub/issues/28