### PR TITLE
Address Module Not Found error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Jinja2==3.1.2
 lxml==5.3.0
 requests==2.27.1
 pillow==10.4.0
+standard-imghdr==3.13.0

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'jinja2',
         'requests',
         'lxml',
-        'pillow'
+        'pillow',
+        'standard-imghdr'
     ]
 )


### PR DESCRIPTION
This Pull Request addresses the "Module Not Found" error that was discussed in [issue #40](https://github.com/dfface/xml2epub/issues/40). 

With the introduction of [PEP 594](https://peps.python.org/pep-0594/#imghdr), some outdated modules, including the `imghdr` module, have been removed from the standard library. To keep things running smoothly, this update includes a switch to `standard-imghdr`, an alternative that offers the same functionality as the old `imghdr` module. 

I also found a helpful [StackOverflow thread](https://stackoverflow.com/questions/79144437/how-to-resolve-no-module-named-imghdr-error-in-python-3-13-with-tweepy) discussing a similar issue and solution, which might be of interest.

If you're eager to try out this fix, you can install it directly from the Git branch with the following command:

```sh
pip3 install -I git+https://github.com/igorlima/xml2epub.git@address-issue-40
```

Thanks.